### PR TITLE
Empty output file bug

### DIFF
--- a/ODEMParser/src/ca/polymtl/odem/parser/ODEM2MDG.java
+++ b/ODEMParser/src/ca/polymtl/odem/parser/ODEM2MDG.java
@@ -75,6 +75,7 @@ public class ODEM2MDG {
 					o.newLine();
 				}
 			}
+			o.flush();
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();


### PR DESCRIPTION
Fixed bug that caused output file to be empty. The buffer wasn't flushed.